### PR TITLE
Fix oscilloscope getting stuck on single event in pull mode

### DIFF
--- a/frontends/tek_fe/CMakeLists.txt
+++ b/frontends/tek_fe/CMakeLists.txt
@@ -19,6 +19,14 @@ if (${CMAKE_SYSTEM_NAME} MATCHES Darwin)
    set(LIBS ${LIBS} -lutil)
 endif()
 
+
+option(VERBOSE_LOGGING "Enable verbose logging" OFF)
+if (VERBOSE_LOGGING)
+  add_compile_definitions(VERBOSE_LOGGING)
+endif()
+
+
+
 add_compile_definitions(UNIX)
 
 

--- a/frontends/tek_fe/include/tek.h
+++ b/frontends/tek_fe/include/tek.h
@@ -5,6 +5,23 @@
 
 #define TEK_NCHANNEL 6
 
+#ifdef VERBOSE_LOGGING
+#include <ctime>
+inline std::string current_time() {
+  std::time_t t = std::time(nullptr);
+  std::tm tm_buf;
+  char buf[26];
+  localtime_r(&t, &tm_buf);
+  asctime_r(&tm_buf, buf);
+  buf[24]=' '; // remove newline
+  return buf;
+}
+
+#define LOG std::cout << current_time()
+#else
+#define LOG if (false) std::cout
+#endif
+
 class tek {
 protected:
    int sockfd;

--- a/frontends/tek_fe/include/tek.h
+++ b/frontends/tek_fe/include/tek.h
@@ -51,6 +51,14 @@ protected:
    virtual void BeginOfRun(){};
    virtual void EndOfRun(){};
 
+   class ReceivingDataGuard {
+   public:
+       explicit ReceivingDataGuard(tek *instrument);
+       ~ReceivingDataGuard();
+   protected:
+       tek* fInstrument = nullptr;
+   };
+
 public:
 
    tek(bool pushMode = false);

--- a/frontends/tek_fe/src/tek.cpp
+++ b/frontends/tek_fe/src/tek.cpp
@@ -289,6 +289,8 @@ bool tek::ConsumeChannel(int npt, int id){
 }
 
 bool tek::ReadData(){
+   LOG << "reading data" << std::endl;
+
    char buff[80];
    int iChannelBlk=0;
    bool gotFooter=false;
@@ -329,7 +331,7 @@ bool tek::ReadData(){
       while(n>0 && buff[0] != '#'){
          n = ReadFromSocket(buff, 1);
       }
-      //std::cout << "Header found" << std::endl;
+      // LOG << "Header found" << std::endl;
 
       n = ReadFromSocket(buff, 1);
       if(buff[0] < '0' || buff[0] > '9') {
@@ -339,22 +341,21 @@ bool tek::ReadData(){
       n = ReadFromSocket(buff, buff[0]-'0');
 
       int npt = CharArrayToInt(buff, n);
-      //printf("got event with %d bytes\n", npt);
 
       if (! ConsumeChannel(npt, iChannelBlk)){
          receivingData = false;
          return false;
       }
-      //std::cout << "Read channel " << iChannelBlk << std::endl;
+      // LOG << "Read channel " << iChannelBlk << std::endl;
 
       //read footer
       n = ReadFromSocket(buff, 1);
       if(n == 1 && buff[0]==10){
-         //std::cout << "Got Last Channel "<< iChannelBlk << std::endl;
+         LOG << "Got Last Channel "<< iChannelBlk << " with " << npt << " bytes" << std::endl;
          gotFooter = true;
       } else if (n==1 && buff[0] == ';'){
-         //std::cout << "Got Channel "<< iChannelBlk << std::endl;
-         iChannelBlk ++; 
+         LOG << "Got Channel "<< iChannelBlk << " with " << npt << " bytes" << std::endl;
+         iChannelBlk ++;
       } else {
          printf("bad footer, got %d with val %d\n", n, buff[0]);
          receivingData = false;
@@ -362,7 +363,7 @@ bool tek::ReadData(){
       }
    }
 
-   //std::cout << "Event done" << std::endl;
+   LOG << "Event done" << std::endl;
    fEventNumber++;
 
    //if pull mode, arm trigger

--- a/frontends/tek_fe/src/tek_cl.cpp
+++ b/frontends/tek_fe/src/tek_cl.cpp
@@ -43,7 +43,7 @@ public:
 	 }
       }
       channels += '\n';
-      //std::cout << "Enabled Channels: " << channels;
+      LOG << "Enabled Channels: " << channels;
       WriteCmd("DAT:SOU " + channels + "\n");
       
       if(IsPushMode()){
@@ -65,7 +65,7 @@ public:
    }
 
    bool ConsumeChannel(int npt, int id){
-      //std::cout << "Consuming channel " << id << ", " << npt << " points" << std::endl;
+      LOG << "Consuming channel " << id << ", " << npt << " points" << std::endl;
       unsigned short buff[10000];
       if (npt > 10000*sizeof(unsigned short)){
          std::cout << "Channel cannot fit in buffer!" << std::endl;

--- a/frontends/tek_fe/src/tek_fe.cpp
+++ b/frontends/tek_fe/src/tek_fe.cpp
@@ -127,7 +127,7 @@ class tek_midas: public tek {
    };
 
    bool ConsumeChannel(int npt, int id){
-      //std::cout << "Consuming channel " << id <<std::endl;
+      // LOG << "Consuming channel " << id <<std::endl;
       char* padc;
 
       /* create ADC0 bank */


### PR DESCRIPTION
Added a scope guard to rearm the trigger if an error occurs in `ReadData()`.

Also, a CMake option is added to make output more verbose.